### PR TITLE
Fix usage of Time::Piece in Module::New::Date

### DIFF
--- a/lib/Module/New/Date.pm
+++ b/lib/Module/New/Date.pm
@@ -2,7 +2,13 @@ package Module::New::Date;
 
 use strict;
 use warnings;
-use base qw( Time::Piece );
+
+use Time::Piece ();
+
+sub new
+{
+    Time::Piece->new
+}
 
 1;
 


### PR DESCRIPTION
Just use Time::Piece as a class to build the value to fit the Module::New::Context contract.
Note that the previous style may be broken by the next release of Time::Piece. See rjbs/Time-Piece#12.
